### PR TITLE
Correcting Strings Comparison

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/discovery/GrailsConventionGroovyPageLocator.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/discovery/GrailsConventionGroovyPageLocator.java
@@ -105,7 +105,7 @@ public class GrailsConventionGroovyPageLocator extends DefaultGroovyPageLocator 
     }
 
     private String getViewNameWithFormat(String viewName, String format) {
-        if (format == null || format == 'all') {
+        if (format == null || format.equals("all")) {
             return viewName;
         }
         return viewName + DOT + format;


### PR DESCRIPTION
This is a Java file. So is important to use "equals comparison" in String and not "==" as we do in groovy files.
